### PR TITLE
Run type checking on 3.9->3.13-dev matrix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
 
   pyright:
     runs-on: ubuntu-latest
-    strategy: 
+    strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13-dev"]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,9 @@ jobs:
 
   pyright:
     runs-on: ubuntu-latest
+    strategy: 
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13-dev"]
 
     steps:
       - uses: actions/checkout@v3
@@ -26,7 +29,7 @@ jobs:
       - name: Set up latest Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
As discussed in Discord.

I'm wondering if there's a necessity to run type checking on intermediate versions.
While I see the reason for running on max version to examine if we aren't accessing deprecated leftovers that might have been slated for removal, I'm doubting a remove->bring back scenario might happen in between.

I mean, [I know about an exception to that](https://docs.python.org/3/library/functions.html#classmethod) which already proves my thinking has edge cases, but yeah, I still did wonder.

Nevertheless, type checking now span versions 3.9->3.13-dev.